### PR TITLE
Fix eslint type's error for params utc of startOfDate & endOfDate #8183

### DIFF
--- a/ui/types/utils/date.d.ts
+++ b/ui/types/utils/date.d.ts
@@ -33,8 +33,8 @@ export namespace date {
   function addToDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function subtractFromDate(date: Date | number | string, options: ModifyDateOptions): Date;
   function adjustDate(date: Date | number | string, options: ModifyDateOptions, utc?: boolean): Date;
-  function startOfDate(date: Date | number | string, option: DateUnitOptions, utc: boolean): Date;
-  function endOfDate(date: Date | number | string, option: DateUnitOptions, utc: boolean): Date;
+  function startOfDate(date: Date | number | string, option: DateUnitOptions, utc?: boolean): Date;
+  function endOfDate(date: Date | number | string, option: DateUnitOptions, utc?: boolean): Date;
   function getMaxDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
   function getMinDate(date: Date | number | string, ...args: (Date | number | string)[]): Date;
   function getDateDiff(date: Date | number | string, subtract: Date | number | string, unit?: string): number;


### PR DESCRIPTION
`startOfDate` and `endOfDate` alert `TS2554: Expected 3 arguments, but got 2.`

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/quasarframework/quasar/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [ ] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar/tree/dev/docs) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
